### PR TITLE
Cleaner file handling during codebase import

### DIFF
--- a/colab.ignore
+++ b/colab.ignore
@@ -1,2 +1,5 @@
+.git
 .env
 .secrets
+poetry.lock
+pyproject.toml

--- a/scripts/codebase_to_colab.py
+++ b/scripts/codebase_to_colab.py
@@ -36,7 +36,11 @@ def create_notebook_from_codebase(codebase_path, output_notebook_path, gemini_pr
     # Get all Python files recursively
     codebase_path = Path(codebase_path)
     # note: files here have paths already
-    codebase_filepaths = [f for f in codebase_path.rglob('*') if f.is_file()]
+    codebase_filepaths = [f for f in codebase_path.rglob('*') if f.is_file() and not str(f).startswith('.git')]
+    # # remove all .git files
+    # for i in range(len(codebase_filepaths)):
+    #     if str(codebase_filepaths[i]).startswith('.git'):
+    #         codebase_filepaths.pop(i)
     
     # remove any files that are irrelevant or sensitive
     with open('colab.ignore', 'r') as f:

--- a/scripts/codebase_to_colab.py
+++ b/scripts/codebase_to_colab.py
@@ -14,6 +14,10 @@ def create_notebook_from_codebase(codebase_path, output_notebook_path, gemini_pr
         gemini_prompt_path (str): Path to a markdown file holding the system prompt for gemini
     """
     
+    # remove output notebook if it already exists, to prevent recursive listing of a notebook within the notebook of a codebase
+    output_notebook_path = Path(output_notebook_path)
+    output_notebook_path.unlink(missing_ok=True)
+
     # Initialize notebook structure
     notebook = {
         "cells": [],


### PR DESCRIPTION
Files that we won't want to include in the notebook are now handled:
- anything in `.git`
- the notebook that we want to write to, to prevent recursive notebooking